### PR TITLE
fix for use the library standalone in a plugin

### DIFF
--- a/Taxonomy_Core.php
+++ b/Taxonomy_Core.php
@@ -99,7 +99,7 @@ if ( ! class_exists( 'Taxonomy_Core' ) ) :
 			$this->object_types  = (array) $object_types;
 
 			// load text domain
-			add_action( 'plugins_loaded', array( $this, 'l10n' ) );
+			add_action( 'plugins_loaded', array( $this, 'l10n' ), 5 );
 			add_action( 'init', array( $this, 'register_taxonomy' ), 5 );
 		}
 


### PR DESCRIPTION
I use Taxonomy Core included in a plugin, without the priority the l10n support is not loaded.